### PR TITLE
Stop HAProxy tests from failing

### DIFF
--- a/tools/test-requires
+++ b/tools/test-requires
@@ -13,6 +13,7 @@ nosexcover
 openstack.nose_plugin
 pep8==1.0.1
 sphinx>=1.1.2
+pycrypto
 paramiko
 ipaddr
 pysqlite


### PR DESCRIPTION
By adding pycrypto to tools/test-requires before paramiko.
