### PR TITLE
Fix probe not deleting on REST request

### DIFF
--- a/balancer/core/api.py
+++ b/balancer/core/api.py
@@ -256,7 +256,7 @@ def lb_delete_probe(conf, lb_id, probe_id):
     db_api.probe_destroy(conf, probe_id)
     device_driver = drivers.get_device_driver(conf, lb['device_id'])
     with device_driver.request_context() as ctx:
-        commands.remove_probe_from_server_farm(ctx, sf, probe)
+        commands.remove_probe_from_loadbalancer(ctx, sf, probe)
     return probe_id
 
 

--- a/balancer/core/commands.py
+++ b/balancer/core/commands.py
@@ -326,6 +326,9 @@ def makeDeleteProbeFromLBChain(ctx, balancer, probe):
     remove_probe_from_server_farm(ctx, balancer.sf, probe)
     delete_probe(ctx, probe)
 
+def remove_probe_from_loadbalancer(ctx, sf_ref, probe_ref):
+    remove_probe_from_server_farm(ctx, sf_ref, probe_ref)
+    delete_probe(ctx, probe_ref)
 
 def add_sticky_to_loadbalancer(ctx, balancer, sticky):
     create_sticky(ctx, sticky)


### PR DESCRIPTION
Fix for issue number 4 that I opened a few days ago. New function created in balancer/core/commands.py with correct parameters and call in balancer/core/api.py changed to call this. Probes now delete successfully on REST call. I have left mysterious makeDeleteProbeFromLBChain function for you to delete if it has no other use.
